### PR TITLE
Enable stats return and disable automatic server restart and match start for private servers

### DIFF
--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -7,9 +7,8 @@ if [ "$CHART_NAME" == "ranked" ]; then
     cp plugins/Bolty/config-readonly.yml plugins/Bolty/config.yml
     sed -i "s/%SERVER-NAME%/$SERVER_NAME/g" plugins/Bolty/config.yml
     echo "[INFO] Ranked server detected... updating PGM config."
-    sed -i 's/%START-TIME%/"30s"/g' plugins/PGM/config.yml
+    sed -i "s/%START-TIME%/30s/g" plugins/PGM/config.yml
     sed -i "s/%MATCH-LIMIT%/6/g" plugins/PGM/config.yml
-    sed -i "s/%STATS-RETURN%/-1/g" plugins/PGM/config.yml
 fi
 
 if [ -n "$MAX_PLAYERS" ]; then
@@ -40,7 +39,6 @@ if [ "$CHART_NAME" != "ranked" ]; then
         /minecraft/plugins/Idly.jar
     sed -i "s/%START-TIME%/-1/g" plugins/PGM/config.yml
     sed -i "s/%MATCH-LIMIT%/-1/g" plugins/PGM/config.yml
-    sed -i 's/%STATS-RETURN%/"3s"/g' plugins/PGM/config.yml
 fi
 
 if [ "$CHART_NAME" = "privateserver" ]; then
@@ -54,11 +52,14 @@ if [ "$NODE_NAME" != "ns522982" ]; then
     rm -f /minecraft/plugins/LPX-*.jar /minecraft/plugins/Matrix-*.jar
 fi
 
-# disable PGM tablist if ingame exists
+# disable PGM tablist and stats return if ingame exists
 TAB_ENABLED=true
+STATS_RETURN=6s
 INGAME=/minecraft/plugins/ingame.jar
 if [[ -f "$INGAME" ]]; then
     TAB_ENABLED=false
+    STATS_RETURN=-1
 fi
 
 sed -i "s/%TAB-ENABLED%/$TAB_ENABLED/g" plugins/PGM/config.yml
+sed -i "s/%STATS-RETURN%/$STATS_RETURN/g" plugins/PGM/config.yml

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -6,12 +6,16 @@ if [ "$CHART_NAME" == "ranked" ]; then
     # temporary hack due to configmap being read only, need to be fixed
     cp plugins/Bolty/config-readonly.yml plugins/Bolty/config.yml
     sed -i "s/%SERVER-NAME%/$SERVER_NAME/g" plugins/Bolty/config.yml
+    echo "[INFO] Ranked server detected... updating PGM config."
+    sed -i 's/%START-TIME%/"30s"/g' plugins/PGM/config.yml
+    sed -i "s/%MATCH-LIMIT%/6/g" plugins/PGM/config.yml
+    sed -i "s/%STATS-RETURN%/-1/g" plugins/PGM/config.yml
 fi
 
 if [ -n "$MAX_PLAYERS" ]; then
-		echo "[INFO] Changing the maximum of players."
-		sed -i '/max-players/d' /minecraft/server.properties
-		echo "max-players=${MAX_PLAYERS}" >> /minecraft/server.properties
+        echo "[INFO] Changing the maximum of players."
+        sed -i '/max-players/d' /minecraft/server.properties
+        echo "max-players=${MAX_PLAYERS}" >> /minecraft/server.properties
 fi
 
 if [ -n "$OPERATORS" ]; then
@@ -29,18 +33,20 @@ if [ -n "$OPERATORS" ]; then
 fi
 
 if [ "$CHART_NAME" != "ranked" ]; then
-    echo "[INFO] Not a ranked server detected... removing Ingame, Events, AutoKiller, Bolty, Matrix and Idly plugins."
+    echo "[INFO] Not a ranked server detected... removing Ingame, Events, AutoKiller, Bolty, Matrix and Idly plugins and updating PGM config."
     rm -f /minecraft/plugins/ingame.jar /minecraft/plugins/Events.jar \
         /minecraft/plugins/AutoKiller-*.jar /minecraft/plugins/Bolty-*.jar \
         /minecraft/plugins/Matrix-*.jar \
         /minecraft/plugins/Idly.jar
-
+    sed -i "s/%START-TIME%/-1/g" plugins/PGM/config.yml
+    sed -i "s/%MATCH-LIMIT%/-1/g" plugins/PGM/config.yml
+    sed -i 's/%STATS-RETURN%/"3s"/g' plugins/PGM/config.yml
 fi
 
 if [ "$CHART_NAME" = "privateserver" ]; then
     echo "[INFO] Private server detected... activating the whitelist."
     sed -i '/white-list/d' /minecraft/server.properties
-	echo "white-list=true" >> /minecraft/server.properties
+    echo "white-list=true" >> /minecraft/server.properties
 fi
 
 if [ "$NODE_NAME" != "ns522982" ]; then

--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -13,9 +13,9 @@ if [ "$CHART_NAME" == "ranked" ]; then
 fi
 
 if [ -n "$MAX_PLAYERS" ]; then
-        echo "[INFO] Changing the maximum of players."
-        sed -i '/max-players/d' /minecraft/server.properties
-        echo "max-players=${MAX_PLAYERS}" >> /minecraft/server.properties
+    echo "[INFO] Changing the maximum of players."
+    sed -i '/max-players/d' /minecraft/server.properties
+    echo "max-players=${MAX_PLAYERS}" >> /minecraft/server.properties
 fi
 
 if [ -n "$OPERATORS" ]; then

--- a/plugins/PGM/config.yml
+++ b/plugins/PGM/config.yml
@@ -34,7 +34,7 @@ map:
 #
 # See the examples above for how to format durations.
 countdown:
-  start: "30s" # After a match cycles or /start
+  start: %START-TIME% # After a match cycles or /start
   cycle: -1 # After a match ends or /cycle
   huddle: -1 # Before a match starts (only recommended for "ranked" matches)
   restart: "20s" # After a restart countdown is queued or /qr
@@ -44,7 +44,7 @@ countdown:
 # Set to -1 to disable either of these options.
 restart:
   uptime: -1 # Queues a restart after this amount of time has elapsed.
-  match-limit: 6 # Queues a restart after this amount of matches.
+  match-limit: %MATCH-LIMIT% # Queues a restart after this amount of matches.
 
 # Changes behaviour when players try to /join a match.
 join:
@@ -70,7 +70,7 @@ ui:
 # Changes how stats are shown.
 stats:
   verbose: true # Enable more detailed stats?
-  show-after: -1 # How long to wait after the match ends to show stats?
+  show-after: %STATS-RETURN% # How long to wait after the match ends to show stats?
   show-best: true # Should show best players stats?
   show-own: true # Should show each players own stats?
 


### PR DESCRIPTION
This PR modifies the startup script and PGM config to allow for different configuration values for ranked and private servers. Currently, the following is changed:

1. Matches will not autostart on private servers, but the previous value of 30s is set for ranked servers.
2. Private servers will not autorestart after 6 matches since they automatically shutdown based on activity.
3. Stats return is enabled after 6 seconds if Ingame is not present to send its stats return.