### PR TITLE
Update groups and enable payload

### DIFF
--- a/plugins/PGM/config.yml
+++ b/plugins/PGM/config.yml
@@ -163,8 +163,8 @@ groups:
     click-link: "https://octc.buycraft.net"
   donor:
     prefix: '&a*'
-    display-name: '&aDonor'
-    description: "&7Supported the server by donating &d❤"
+    display-name: '&aSupporter'
+    description: "&7Supported the server &d❤"
     click-link: "https://octc.buycraft.net"
   mapmaker:
     prefix: '&9*'
@@ -183,18 +183,10 @@ groups:
     display-name: '&4Supreme Overlord'
     description: "&7A notable person from the &e&lOvercast &4&lNetwork"
     click-link: "https://oc.tc"
-  completionist-10:
-    prefix: '&c*'
-    display-name: '&6Completionist'
-    description: '&7Completed the &eSeason 10 &6&lBattle Pass'
-  completionist-9:
-    prefix: '&6*'
-    display-name: '&6Completionist'
-    description: '&7Completed the &eSeason 9 &6&lBattle Pass'
-  completionist-8:
+  completionist-21:
     prefix: '&e*'
     display-name: '&6Completionist'
-    description: '&7Completed the &eSeason 8 &6&lBattle Pass'
+    description: '&7Completed the &eSeason 21 &6&lBattle Pass'
   builder:
     prefix: '&b*'
     display-name: '&bBuilder'
@@ -423,3 +415,4 @@ database-uri: ""
 # Experimental features that are not yet stable.
 experiments:
   unload-non-match-worlds: "true"
+  payload: true


### PR DESCRIPTION
- Supporter's group name kept intact since it's still in use
- enable payload: requested, i'm not sure if the other experiment is supposed to have quotation marks on "true", but they've always been there. 

https://github.com/bolt-rip/config-pgm/commit/48269778346f2aecef7580f8327eebf869fb7c5f